### PR TITLE
Fixed wrong server-translations-api version

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -9,7 +9,7 @@ org.gradle.jvmargs=-Xmx1G
 	loader_version=0.16.10
 
 # Mod Properties
-	mod_version = 2.0.2
+	mod_version = 2.0.3
 	maven_group = eu.midnightdust
 	archives_base_name = puddles
 	release_type=release
@@ -20,4 +20,4 @@ org.gradle.jvmargs=-Xmx1G
 	fabric_version=0.119.5+1.21.5
 	midnightlib_version=1.6.10+1.21.4-fabric
 	polymer_version=0.12.1+1.21.5-rc2
-	server_translation_version=2.4.0+1.21.2-rc1
+	server_translation_version=2.5.0+1.21.5-rc1


### PR DESCRIPTION
This pull request updates the versioning in the `gradle.properties` file to reflect new releases of the mod and its dependencies.

Version updates:

* Updated `mod_version` from `2.0.2` to `2.0.3` to reflect the new release of the mod.
* Updated `server_translation_version` from `2.4.0+1.21.2-rc1` to `2.5.0+1.21.5-rc1` to align with the latest compatible server translation version.